### PR TITLE
Import orphan Typeable Errno instance from base-orphans

### DIFF
--- a/hen.cabal
+++ b/hen.cabal
@@ -22,7 +22,7 @@ Library
     Default-language:   Haskell2010
 
     Build-depends:      base                      == 4.7.* || == 4.6.* || == 4.5.*
-                      , base-orphans              == 0.3.*
+                      , base-orphans              == 0.4.*
                       , transformers              == 0.3.*
                       , mtl                       == 2.1.* || == 2.0.*
                       , exceptions                == 0.3.*

--- a/hen.cabal
+++ b/hen.cabal
@@ -22,6 +22,7 @@ Library
     Default-language:   Haskell2010
 
     Build-depends:      base                      == 4.7.* || == 4.6.* || == 4.5.*
+                      , base-orphans              == 0.3.*
                       , transformers              == 0.3.*
                       , mtl                       == 2.1.* || == 2.0.*
                       , exceptions                == 0.3.*

--- a/src/System/Xen/Errors.hs
+++ b/src/System/Xen/Errors.hs
@@ -12,6 +12,7 @@ module System.Xen.Errors
     ) where
 
 import Control.Exception (Exception)
+import Data.Orphans ()
 import Data.Typeable (Typeable)
 import Foreign.C (CInt)
 import Foreign.C.Error (Errno(..))
@@ -21,7 +22,6 @@ import Control.Monad.Trans (MonadIO(liftIO))
 
 deriving instance Ord Errno
 deriving instance Show Errno
-deriving instance Typeable Errno
 
 -- | This error can be raised if handle can not be opened, insufficient rights
 -- for example.


### PR DESCRIPTION
As a heads-up: starting in GHC 7.10 (i.e., `base-4.8.0.0`), there is a `Typeable Errno` instance (as well as a `Typeable` instance for every data type). To avoid potential instance conflicts that may arise if this package is updated to use `base-4.8.0.0`, I replaced the orphan `Typeable Errno` instance in `hen` with the one in `base-orphans` (which is [identical](https://github.com/haskell-compat/base-orphans/blob/0a62d9e77e9fd242540b1e6e104ead9128e93ad1/src/Data/Orphans.hs#L1220)). In addition, this should allow `hen` to be used with other packages that transitively depend on `base-orphans` without running into instance conflicts on old versions of GHC.
